### PR TITLE
Attempt to guess GitHub repo name

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -85,7 +85,7 @@ _.forEach(files, function (file) {
         break
 
       default:
-        doneDressing('- [ ] "' + file + '" errored, code :' + err.code)
+        doneDressing('- [ ] "' + file + '" errored, code: ' + (err.code || '<unknown>') + '\n' + err)
         break
 
     }

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -5,6 +5,7 @@ var Promise = require('bluebird')
 var program = require('commander')
 var fs = Promise.promisifyAll(require('fs'))
 var rfs = require('fs-readdir-recursive')
+var spawnSync = require('child_process').spawnSync
 
 var pkg = require('../package.json')
 var sauce = require('../lib/gh-sauce.js')
@@ -55,11 +56,26 @@ if (program.safe) {
   config.safe = program.safe
 }
 if (program.repo) {
+  if (!program.repo.match(/^https:\/\/github\.com/)) {
+    program.repo = 'https://github.com/' + program.repo
+  }
   config.repo = program.repo
+} else {
+  try {
+    var repoURL = String(spawnSync('git', ['remote', 'get-url', 'origin']).stdout).trim()
+    if (repoURL.match(/^https:\/\/github\.com/)) {
+      config.repo = repoURL.replace(/\.git$/, '')
+    } else {
+      throw new Error() // go to catch clause
+    }
+  } catch (e) {
+    console.log('WARNING: failed to determine GitHub repo URL')
+  }
 }
 
 var print = program.print
 
+if (!print && !program.repo) console.log('# Guessing repo name: ' + config.repo.replace(/^https:\/\/github\.com\//, '') + '\n> Use `--repo` to customize')
 if (!print) console.log('# Dressing ' + files.join(', ') + ' with some gh-sauce...\n')
 
 function doneDressing (msg) {

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -5,7 +5,6 @@ var Promise = require('bluebird')
 var program = require('commander')
 var fs = Promise.promisifyAll(require('fs'))
 var rfs = require('fs-readdir-recursive')
-var spawnSync = require('child_process').spawnSync
 
 var pkg = require('../package.json')
 var sauce = require('../lib/gh-sauce.js')
@@ -56,26 +55,13 @@ if (program.safe) {
   config.safe = program.safe
 }
 if (program.repo) {
-  if (!program.repo.match(/^https:\/\/github\.com/)) {
-    program.repo = 'https://github.com/' + program.repo
-  }
   config.repo = program.repo
-} else {
-  try {
-    var repoURL = String(spawnSync('git', ['remote', 'get-url', 'origin']).stdout).trim()
-    if (repoURL.match(/^https:\/\/github\.com/)) {
-      config.repo = repoURL.replace(/\.git$/, '')
-    } else {
-      throw new Error() // go to catch clause
-    }
-  } catch (e) {
-    console.log('WARNING: failed to determine GitHub repo URL')
-  }
 }
+
+config.print = !program.print
 
 var print = program.print
 
-if (!print && !program.repo) console.log('# Guessing repo name: ' + config.repo.replace(/^https:\/\/github\.com\//, '') + '\n> Use `--repo` to customize')
 if (!print) console.log('# Dressing ' + files.join(', ') + ' with some gh-sauce...\n')
 
 function doneDressing (msg) {

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -54,9 +54,8 @@ var config = {}
 if (program.safe) {
   config.safe = program.safe
 }
-config.print = !program.print
 
-var print = program.print
+var print = config.print = !program.print
 
 if (program.repo) {
   config.repo = program.repo
@@ -80,19 +79,19 @@ if (program.repo) {
     repoGuess = 'package.json'
   } catch (err) {}
 
-  if (!print && config.repo) {
+  if (print && config.repo) {
     console.log('# Guessing repo name: ' + config.repo.replace(/^https:\/\/github\.com\//, ''))
     if (repoGuess) console.log('> Guessed from ' + repoGuess)
     console.log('> Use `--repo` to customize')
   }
 }
-if (!print) console.log('# Dressing ' + files.join(', ') + ' with some gh-sauce...\n')
+if (print) console.log('# Dressing ' + files.join(', ') + ' with some gh-sauce...\n')
 
 function doneDressing (msg) {
-  if (!print) console.log(msg)
+  if (print) console.log(msg)
   --files.length
   if (files.length === 0) {
-    if (!print) console.log('\nDone! 🍧')
+    if (print) console.log('\nDone! 🍧')
   }
 }
 

--- a/lib/gh-sauce.js
+++ b/lib/gh-sauce.js
@@ -16,32 +16,12 @@ module.exports.config = {
   safe: false
 }
 
-var repoGuess
-
-try {
-  var repoURL = String(spawnSync('git', ['remote', 'get-url', 'origin']).stdout).trim()
-  if (/^https:\/\/github\.com/.test(repoURL)) {
-    // HTTPS
-    config.repo = repoURL.replace(/\.git$/, '')
-  } else if (/^git@github\.com:(.+)\.git$/.test(repoURL)) {
-    config.repo = repoURL.match(/^git@github\.com:(.+)\.git$/)[1]
-  }
-  repoGuess = 'the git `origin` remote'
-} catch (err) {}
-
-try {
-  var cwdPkg = require(process.cwd() + '/package.json')
-  module.exports.config.repo = cwdPkg.homepage
-  repoGuess = 'package.json'
-} catch (err) {}
-
 module.exports.dress = function (text, config) {
   if (typeof text !== 'string') {
     throw new TypeError('Expected `text` (arg #1) to be a string in sauce#dress(text, config)')
   }
 
   config = typeof config === 'object' && config || {}
-  var hadRepo = !!config.repo
   config = _.assign(_.clone(module.exports.config), config)
 
   if (config.repo === null) {
@@ -50,12 +30,6 @@ module.exports.dress = function (text, config) {
     throw new TypeError('Invalid config for `repo`: ' + require('util').inspect(config.repo))
   } else if (!/^https:\/\/github\.com/.test(config.repo)) {
     config.repo = 'https://github.com/' + config.repo
-  }
-
-  if (config.print && !hadRepo) {
-    console.log('# Guessing repo name: ' + config.repo.replace(/^https:\/\/github\.com\//, ''))
-    if (repoGuess) console.log('> Guessed from ' + repoGuess)
-    console.log('> Use `--repo` to customize')
   }
 
   var issues = {}

--- a/lib/gh-sauce.js
+++ b/lib/gh-sauce.js
@@ -9,15 +9,30 @@
 'use strict'
 
 var _ = require('lodash')
+var spawnSync = require('child_process').spawnSync
 
 module.exports.config = {
   repo: null,
   safe: false
 }
 
+var repoGuess
+
+try {
+  var repoURL = String(spawnSync('git', ['remote', 'get-url', 'origin']).stdout).trim()
+  if (/^https:\/\/github\.com/.test(repoURL)) {
+    // HTTPS
+    config.repo = repoURL.replace(/\.git$/, '')
+  } else if (/^git@github\.com:(.+)\.git$/.test(repoURL)) {
+    config.repo = repoURL.match(/^git@github\.com:(.+)\.git$/)[1]
+  }
+  repoGuess = 'the git `origin` remote'
+} catch (err) {}
+
 try {
   var cwdPkg = require(process.cwd() + '/package.json')
   module.exports.config.repo = cwdPkg.homepage
+  repoGuess = 'package.json'
 } catch (err) {}
 
 module.exports.dress = function (text, config) {
@@ -26,12 +41,21 @@ module.exports.dress = function (text, config) {
   }
 
   config = typeof config === 'object' && config || {}
+  var hadRepo = !!config.repo
   config = _.assign(_.clone(module.exports.config), config)
 
   if (config.repo === null) {
     throw new Error('Can\'t figure out repo and it was not provided')
   } else if (typeof config.repo !== 'string') {
     throw new TypeError('Invalid config for `repo`')
+  } else if (!/^https:\/\/github\.com/.test(config.repo)) {
+    config.repo = 'https://github.com/' + config.repo
+  }
+
+  if (config.print && !hadRepo) {
+    console.log('# Guessing repo name: ' + config.repo.replace(/^https:\/\/github\.com\//, ''))
+    if (repoGuess) console.log('> Guessed from ' + repoGuess)
+    console.log('> Use `--repo` to customize')
   }
 
   var issues = {}

--- a/lib/gh-sauce.js
+++ b/lib/gh-sauce.js
@@ -47,7 +47,7 @@ module.exports.dress = function (text, config) {
   if (config.repo === null) {
     throw new Error('Can\'t figure out repo and it was not provided')
   } else if (typeof config.repo !== 'string') {
-    throw new TypeError('Invalid config for `repo`')
+    throw new TypeError('Invalid config for `repo`: ' + require('util').inspect(config.repo))
   } else if (!/^https:\/\/github\.com/.test(config.repo)) {
     config.repo = 'https://github.com/' + config.repo
   }


### PR DESCRIPTION
This uses the `origin` remote of the current git repository.
If the user passes `--repo user/repo`, it will be expanded to `https://github.com/user/repo`.

Bonus: print the stack trace if there is an unknown error. 